### PR TITLE
Add json testsuite reference

### DIFF
--- a/.dotstop_extensions/README.md
+++ b/.dotstop_extensions/README.md
@@ -2,7 +2,7 @@
 
 The custom references can be used by specifying the arguments as specified in the constructor (see references.py) at the top of the trudag item files under references:
 
-For the `CPPTestReferenceTestsuite` an example is:
+For the `JSONTestsuiteReference` an example is:
 ```
 ---
 ...
@@ -18,7 +18,7 @@ references:
 ---
 ```
 
-For the `JSONTestsuiteReference` an example is:
+For the `CPPTestReference` an example is:
 ```
 ---
 ...

--- a/.dotstop_extensions/README.md
+++ b/.dotstop_extensions/README.md
@@ -15,6 +15,7 @@ references:
     - "/json_tests/fail2.json"
     - "/json_tests/fail3.json"
   description: "invalid json"
+  remove_other_test_data_lines: False # optional, the default value is True 
 ---
 ```
 

--- a/.dotstop_extensions/README.md
+++ b/.dotstop_extensions/README.md
@@ -1,0 +1,31 @@
+# Custom references
+
+The custom references can be used by specifying the arguments as specified in the constructor (see references.py) at the top of the trudag item files under references:
+
+For the `CPPTestReferenceTestsuite` an example is:
+```
+---
+...
+
+references:
+- type: JSON_testsuite
+  name: "compliance tests from json.org:expected failures"
+  path: "tests/src/unit-testsuites.cpp"
+  test_suite_paths: 
+    - "/json_tests/fail2.json"
+    - "/json_tests/fail3.json"
+  description: "invalid json"
+---
+```
+
+For the `JSONTestsuiteReference` an example is:
+```
+---
+...
+
+references:
+- type: cpp_test
+  name: "compliance tests from json.org:expected failures"
+  path: "tests/src/unit-testsuites.cpp"
+---
+```

--- a/.dotstop_extensions/references.py
+++ b/.dotstop_extensions/references.py
@@ -26,7 +26,8 @@ class CPPTestReference(BaseReference):
     Represents a reference to a specific section within a C++ test file. The class
     assumes that the C++ test sections are defined using `SECTION("name")` or
     `TEST_CASE("name")` syntax, where the section name can be nested using
-    colon-separated names (e.g., "testcase1:section1:section2"). 
+    colon-separated names (e.g., "testcase1:section1:section2"). We assume that the 
+    section path is unique within the file.
     
     Additionally, the opening brace `{` must be on the line immediately after the 
     section declaration, and the closing brace `}` must have the same indentation 
@@ -63,13 +64,13 @@ class CPPTestReference(BaseReference):
         for the first occurrence of a line containing either SECTION("section1")
         or TEST_CASE("section1") where section1 matches the first part of the section name. 
         This is done iteratively for nested sections until the full section name sequence 
-        is matched.
+        is matched. This implicitly assumes that the section paths are unique within the file.
 
         Args:
             file_lines: List of lines from the C++ test file
 
         Returns:
-            Line index where the section starts
+            Line index where the section starts (i.e. the line containing SECTION or TEST_CASE)
         """
         section_names = self._name.split(':')
         for line_number, line in enumerate(file_lines):

--- a/.dotstop_extensions/test_references.py
+++ b/.dotstop_extensions/test_references.py
@@ -2,7 +2,7 @@ import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import patch, mock_open
-from references import CPPTestReference
+from references import CPPTestReference, JSONTestsuiteReference
 
 
 @pytest.fixture
@@ -225,3 +225,10 @@ def test_nested_section_extraction(temp_cpp_file):
     ref = CPPTestReference("basic_test:section1:nested_section", temp_cpp_file)
     section = ref.get_section()
     assert 'nested_section' in section
+
+def test_testsuite_json_loading():
+    """Test TestsuiteReference initialization and type."""
+    suite_ref = JSONTestsuiteReference("name", "path", "/json_tests/fail2.json", "description")
+    json = suite_ref.get_testsuite_content()
+    assert json == '["Unclosed array"'
+    

--- a/.dotstop_extensions/test_references.py
+++ b/.dotstop_extensions/test_references.py
@@ -1,7 +1,7 @@
 import pytest
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 from references import CPPTestReference, JSONTestsuiteReference
 
 
@@ -197,8 +197,8 @@ def test_find_section_end_no_closing_brace():
 def test_remove_leading_whitespace_preserve_indentation():
     """Test whitespace removal while preserving indentation."""
     ref = CPPTestReference("test", "test.cpp")
-    # 4 - 8 - 4 spaces here
-    text = "    line1\n        line2\n    line3\n"
+    # 4 - (tab+4) - 4 spaces here
+    text = "    line1\n\t    line2\n    line3\n"
     # 0 - 4 - 0 spaces here
     expected = "line1\n    line2\nline3\n"
     result = ref.remove_leading_whitespace_preserve_indentation(text)
@@ -213,7 +213,7 @@ def test_remove_leading_whitespace_preserve_indentation_tabs():
 
     expected_output = '''SECTION("empty object")
 {
-\tCHECK(parser_helper("{}") == json(json::value_t::object));
+    CHECK(parser_helper("{}") == json(json::value_t::object));
 }
 '''
     ref = CPPTestReference("test", "test.cpp")
@@ -338,19 +338,13 @@ def test_type_classmethod_JSON_testsuite():
 
 def test_is_json_test_line_valid_cases():
     """Test is_json_test_line with valid JSON test lines."""
-    # Test with comment prefix and .json", suffix
-    assert JSONTestsuiteReference.is_json_test_line('// TEST_DATA_DIRECTORY "/json_tests/fail1.json",')
-    assert JSONTestsuiteReference.is_json_test_line('//TEST_DATA_DIRECTORY "/json_tests/fail2.json",')
-    assert JSONTestsuiteReference.is_json_test_line('TEST_DATA_DIRECTORY "/json_tests/fail3.json",')
-    
-    # Test with .json" suffix (no comma)
-    assert JSONTestsuiteReference.is_json_test_line('// TEST_DATA_DIRECTORY "/json_tests/pass1.json"')
-    assert JSONTestsuiteReference.is_json_test_line('//TEST_DATA_DIRECTORY "/json_tests/pass2.json"')
-    assert JSONTestsuiteReference.is_json_test_line('TEST_DATA_DIRECTORY "/json_tests/pass3.json"')
-    
-    # Test with whitespace
-    assert JSONTestsuiteReference.is_json_test_line('    // TEST_DATA_DIRECTORY "/json_tests/test.json",    ')
-    assert JSONTestsuiteReference.is_json_test_line('\t\tTEST_DATA_DIRECTORY "/path/to/file.json"\t')
+    # line from "json.org examples"
+    assert JSONTestsuiteReference.is_json_test_line('    std::ifstream f(TEST_DATA_DIRECTORY "/json.org/5.json");')
+    # line from "compliance tests from json.org"
+    assert JSONTestsuiteReference.is_json_test_line('    TEST_DATA_DIRECTORY "/json_tests/fail2.json",')
+    # line from "nst's JSONTestSuite (2)"
+    assert JSONTestsuiteReference.is_json_test_line('TEST_DATA_DIRECTORY "/nst_json_testsuite2/test_parsing/y_string_surrogates_U+1D11E_MUSICAL_SYMBOL_G_CLEF.json",')
+
 
 def test_filter_other_test_data_lines_keeps_relevant_lines():
     """Test filter_other_test_data_lines keeps lines with relevant test suite paths."""

--- a/.dotstop_extensions/test_references.py
+++ b/.dotstop_extensions/test_references.py
@@ -35,13 +35,51 @@ TEST_CASE("another_test")
 '''
 
 @pytest.fixture
+def sample_testsuite_test():
+    """Sample JSON testsuite content for testing."""
+    return '''TEST_CASE("compliance tests from json.org")
+{
+    // test cases are from https://json.org/JSON_checker/
+
+    SECTION("expected failures")
+    {
+        for (const auto* filename :
+                {
+                    TEST_DATA_DIRECTORY "/json_tests/fail1.json",
+                    TEST_DATA_DIRECTORY "/json_tests/fail2.json",
+                    TEST_DATA_DIRECTORY "/json_tests/fail3.json",
+                    \\ TEST_DATA_DIRECTORY "/json_tests/fail4.json",
+                })
+        {
+            CAPTURE(filename)
+            std::ifstream f(filename);
+            json _;
+            CHECK_THROWS_AS(_ = json::parse(f), json::parse_error&);
+        }
+    }
+}
+'''
+
+def create_temp_file(content, suffix='.txt'):
+    """Helper method to create temporary files for testing."""
+    with tempfile.NamedTemporaryFile(mode='w', suffix=suffix, delete=False) as f:
+        f.write(content)
+        f.flush()
+        return Path(f.name)
+
+@pytest.fixture
 def temp_cpp_file(sample_cpp_content):
     """Create a temporary C++ file for testing."""
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.cpp', delete=False) as f:
-        f.write(sample_cpp_content)
-        f.flush()
-        yield Path(f.name)
-    Path(f.name).unlink()
+    temp_file = create_temp_file(sample_cpp_content, '.cpp')
+    yield temp_file
+    temp_file.unlink()
+
+@pytest.fixture
+def temp_cpp_file_with_testsuite(sample_testsuite_test):
+    """Create a temporary C++ file with testsuite content."""
+    temp_file = create_temp_file(sample_testsuite_test, '.cpp')
+    yield temp_file
+    temp_file.unlink()
 
 def test_init():
     """Test CPPTestReference initialization."""
@@ -100,7 +138,7 @@ def test_find_section_start_not_found():
     with pytest.raises(ValueError, match="Section start not found"):
         ref.find_section_start(lines)
 
-def test_find_section_end_valid():
+def test_find_section_end():
     """Test finding section end with matching braces."""
     lines = [
         'SECTION("test")\n',
@@ -159,21 +197,23 @@ def test_find_section_end_no_closing_brace():
 def test_remove_leading_whitespace_preserve_indentation():
     """Test whitespace removal while preserving indentation."""
     ref = CPPTestReference("test", "test.cpp")
+    # 4 - 8 - 4 spaces here
     text = "    line1\n        line2\n    line3\n"
+    # 0 - 4 - 0 spaces here
     expected = "line1\n    line2\nline3\n"
     result = ref.remove_leading_whitespace_preserve_indentation(text)
     assert result == expected
 
 def test_remove_leading_whitespace_preserve_indentation_tabs():
-    test_input = '''            SECTION("empty object")
-            {
-                CHECK(parser_helper("{}") == json(json::value_t::object));
-            }
+    test_input = '''\t\t\tSECTION("empty object")
+\t\t\t{
+\t\t\t\tCHECK(parser_helper("{}") == json(json::value_t::object));
+\t\t\t}
 '''
 
     expected_output = '''SECTION("empty object")
 {
-    CHECK(parser_helper("{}") == json(json::value_t::object));
+\tCHECK(parser_helper("{}") == json(json::value_t::object));
 }
 '''
     ref = CPPTestReference("test", "test.cpp")
@@ -182,11 +222,13 @@ def test_remove_leading_whitespace_preserve_indentation_tabs():
 
 def test_get_section_integration(temp_cpp_file):
     """Test complete section extraction."""
-    ref = CPPTestReference("basic_test", str(temp_cpp_file))
+    ref = CPPTestReference("basic_test:section1", str(temp_cpp_file))
     section = ref.get_section()
-    assert 'TEST_CASE("basic_test")' in section
+    assert 'TEST_CASE("basic_test")' not in section
     assert 'SECTION("section1")' in section
     assert 'CHECK(true)' in section
+    assert 'SECTION("nested_section")' in section
+    assert 'SECTION("section2")' not in section
 
 def test_get_section_file_not_found():
     """Test exception when file is not found."""
@@ -200,6 +242,8 @@ def test_content_property(temp_cpp_file):
     content = ref.content
     assert isinstance(content, bytes)
     assert b'TEST_CASE("basic_test")' in content
+    assert b'SECTION("section2")' in content
+    assert b'TEST_CASE("another_test")' not in content
 
 def test_as_markdown(temp_cpp_file):
     """Test markdown formatting."""
@@ -231,4 +275,184 @@ def test_testsuite_json_loading():
     suite_ref = JSONTestsuiteReference("name", "path", ["/json_tests/fail2.json"], "description")
     json = suite_ref.get_testsuite_content("/json_tests/fail2.json")
     assert json == '["Unclosed array"'
+
+def test_json_testsuite_reference_content(temp_cpp_file_with_testsuite, sample_testsuite_test):
+    """Test JSONTestsuiteReference content property."""
+    suite_ref = JSONTestsuiteReference("compliance tests from json.org:expected failures", str(temp_cpp_file_with_testsuite), ["/json_tests/fail2.json", "/json_tests/fail3.json"], "description")
     
+    content = suite_ref.content
+    assert isinstance(content, bytes)
+
+    decoded_content = content.decode('utf-8')
+
+    relevant_section = '\n'.join(sample_testsuite_test.split('\n')[4:-2])
+
+    # content should include the section from the C++ test file and the JSON files
+    assert relevant_section in decoded_content
+    # "/json_tests/fail2.json"
+    assert '["Unclosed array"' in decoded_content
+    # "/json_tests/fail3.json"
+    assert '{unquoted_key: "keys must be quoted"}' in decoded_content
+
+def test_json_testsuite_reference_init_valid():
+    """Test JSONTestsuiteReference initialization with valid parameters."""
+    test_suite_paths = ["tests/data/json_tests/pass1.json", "tests/data/json_tests/pass2.json"]
+    description = "Test suite for valid JSON parsing"
+    
+    with patch.object(JSONTestsuiteReference, 'get_testsuite_content') as mock_get_content:
+        mock_get_content.side_effect = lambda path: f"content of {path}"
+        
+        ref = JSONTestsuiteReference("test_section", "test.cpp", test_suite_paths, description)
+        
+        # Test initialization
+        assert ref._name == "test_section"
+        assert ref._path == Path("test.cpp")
+        assert ref._test_suite_paths == test_suite_paths
+        assert ref._description == description
+        
+        # Test that content was loaded for each path
+        assert len(ref._loaded_json_map) == 2
+        assert ref._loaded_json_map["tests/data/json_tests/pass1.json"] == "content of tests/data/json_tests/pass1.json"
+        assert ref._loaded_json_map["tests/data/json_tests/pass2.json"] == "content of tests/data/json_tests/pass2.json"
+        
+        # Verify get_testsuite_content was called for each path
+        assert mock_get_content.call_count == 2
+
+def test_json_testsuite_reference_init_invalid_paths_type():
+    """Test JSONTestsuiteReference initialization with invalid test_suite_paths type."""
+    with pytest.raises(ValueError, match="test_suite_paths must be a list of strings"):
+        JSONTestsuiteReference("test_section", "test.cpp", "not_a_list", "description")
+
+def test_type_classmethod_JSON_testsuite():
+    """Test the type class method."""
+    assert JSONTestsuiteReference.type() == "JSON_testsuite"
+
+def test_is_json_test_line_valid_cases():
+    """Test is_json_test_line with valid JSON test lines."""
+    # Test with comment prefix and .json", suffix
+    assert JSONTestsuiteReference.is_json_test_line('// TEST_DATA_DIRECTORY "/json_tests/fail1.json",')
+    assert JSONTestsuiteReference.is_json_test_line('//TEST_DATA_DIRECTORY "/json_tests/fail2.json",')
+    assert JSONTestsuiteReference.is_json_test_line('TEST_DATA_DIRECTORY "/json_tests/fail3.json",')
+    
+    # Test with .json" suffix (no comma)
+    assert JSONTestsuiteReference.is_json_test_line('// TEST_DATA_DIRECTORY "/json_tests/pass1.json"')
+    assert JSONTestsuiteReference.is_json_test_line('//TEST_DATA_DIRECTORY "/json_tests/pass2.json"')
+    assert JSONTestsuiteReference.is_json_test_line('TEST_DATA_DIRECTORY "/json_tests/pass3.json"')
+    
+    # Test with whitespace
+    assert JSONTestsuiteReference.is_json_test_line('    // TEST_DATA_DIRECTORY "/json_tests/test.json",    ')
+    assert JSONTestsuiteReference.is_json_test_line('\t\tTEST_DATA_DIRECTORY "/path/to/file.json"\t')
+
+def test_filter_other_test_data_lines_keeps_relevant_lines():
+    """Test filter_other_test_data_lines keeps lines with relevant test suite paths."""
+    test_suite_paths = ["json_tests/pass1.json", "json_tests/pass2.json"]
+    
+    with patch.object(JSONTestsuiteReference, 'get_testsuite_content') as mock_get_content:
+        mock_get_content.return_value = "sample json content"
+        
+        ref = JSONTestsuiteReference("test_section", "test.cpp", test_suite_paths, "Test description")
+        
+        input_text = '''TEST_CASE("test")
+{
+    // TEST_DATA_DIRECTORY "/json_tests/pass1.json",
+    // TEST_DATA_DIRECTORY "/json_tests/fail1.json",
+    TEST_DATA_DIRECTORY "/json_tests/pass2.json",
+    TEST_DATA_DIRECTORY "/json_tests/other.json",
+    CHECK(true);
+}'''
+
+def test_get_single_json_as_markdown_small_content():
+    """Test get_single_json_as_markdown with small JSON content for two files."""
+    test_suite_paths = ["json_tests/small.json", "json_tests/large.json"]
+
+    def mock_content_side_effect(path):
+        if path == "json_tests/small.json":
+            return '{"test": "value1"}'
+        elif path == "json_tests/large.json":
+            return 'test\n'*500
+        return ""
+    
+    with patch.object(JSONTestsuiteReference, 'get_testsuite_content') as mock_get_content:
+        mock_get_content.side_effect = mock_content_side_effect
+        
+        ref = JSONTestsuiteReference("test_section", "test.cpp", test_suite_paths, "Test description")
+        
+        result1 = ref.get_single_json_as_markdown("json_tests/small.json")
+        assert "- JSON Testsuite: json_tests/small.json" in result1
+        assert "```json" in result1
+        assert '{"test": "value1"}' in result1
+        
+        result2 = ref.get_single_json_as_markdown("json_tests/large.json")
+        assert "- JSON Testsuite: json_tests/large.json" in result2
+        assert '[Link to file]' in result2
+
+def test_get_all_json_as_markdown():
+    """Test get_all_json_as_markdown with multiple JSON files."""
+    test_suite_paths = ["json_tests/file1.json", "json_tests/file2.json"]
+    
+    def mock_content_side_effect(path):
+        if path == "json_tests/file1.json":
+            return '{"name": "test1"}'
+        elif path == "json_tests/file2.json":
+            return '{"name": "test2"}'
+        return ""
+    
+    with patch.object(JSONTestsuiteReference, 'get_testsuite_content') as mock_get_content:
+        mock_get_content.side_effect = mock_content_side_effect
+        
+        ref = JSONTestsuiteReference("test_section", "test.cpp", test_suite_paths, "Test description")
+        
+        result = ref.get_all_json_as_markdown()
+        
+        # Should contain both JSON files
+        assert "- JSON Testsuite: json_tests/file1.json" in result
+        assert "- JSON Testsuite: json_tests/file2.json" in result
+        
+        # Should contain both JSON contents
+        assert '{"name": "test1"}' in result
+        assert '{"name": "test2"}' in result
+        
+        # Should have proper separation between files
+        assert result.count("```json") == 2
+
+def test_as_markdown():
+    """Test as_markdown method with complete output structure."""
+    test_suite_paths = ["json_tests/test1.json", "json_tests/test2.json"]
+    
+    def mock_content_side_effect(path):
+        if path == "json_tests/test1.json":
+            return '{"test": "value1"}'
+        elif path == "json_tests/test2.json":
+            return '{"test": "value2"}'
+        return ""
+    
+    with patch.object(JSONTestsuiteReference, 'get_testsuite_content') as mock_get_content, \
+         patch.object(JSONTestsuiteReference, 'get_section') as mock_get_section:
+        
+        mock_get_content.side_effect = mock_content_side_effect
+        mock_get_section.return_value = '''TEST_CASE("test")
+{
+    // TEST_DATA_DIRECTORY "/json_tests/test1.json",
+    CHECK(true);
+}'''
+        
+        ref = JSONTestsuiteReference("test_section", "test.cpp", test_suite_paths, "Test JSON files")
+        
+        result = ref.as_markdown()
+        
+        # Should contain description
+        assert "Description: Test JSON files" in result
+        
+        # Should contain JSON content
+        assert "JSON Testsuite: json_tests/test1.json" in result
+        assert "JSON Testsuite: json_tests/test2.json" in result
+        assert '{"test": "value1"}' in result
+        assert '{"test": "value2"}' in result
+        
+        # Should contain C++ test content
+        assert "cpp-test:" in result
+        assert "```cpp" in result
+        assert "CHECK(true);" in result
+        
+        # Should be indented (starts with tab)
+        assert result.startswith('\t')

--- a/.dotstop_extensions/test_references.py
+++ b/.dotstop_extensions/test_references.py
@@ -228,7 +228,7 @@ def test_nested_section_extraction(temp_cpp_file):
 
 def test_testsuite_json_loading():
     """Test TestsuiteReference initialization and type."""
-    suite_ref = JSONTestsuiteReference("name", "path", "/json_tests/fail2.json", "description")
-    json = suite_ref.get_testsuite_content()
+    suite_ref = JSONTestsuiteReference("name", "path", ["/json_tests/fail2.json"], "description")
+    json = suite_ref.get_testsuite_content("/json_tests/fail2.json")
     assert json == '["Unclosed array"'
     

--- a/scripts/clean_trudag_output.py
+++ b/scripts/clean_trudag_output.py
@@ -41,6 +41,7 @@ def clean_file(filepath):
         lines = f.readlines()
     new_lines = [clean_line(line) for line in lines]
     new_lines = [line for line in new_lines if not remove_line(line)]  # Remove empty lines
+    new_lines = [line[2:] if line.startswith('\t\t') else line for line in new_lines]
     if new_lines != lines:
         with open(filepath, 'w', encoding='utf-8') as f:
             f.writelines(new_lines)


### PR DESCRIPTION
Add test references for the trudag tool.
- The cpp test reference extracts the defined cpp test section and this section is included in the report and the hash calculation for the corresponding trudag item.
- The JSON test suite reference extracts the defined JSON files and the cpp test section that performs the test using the specified JSON file. All these information are used for hashing but in the report the cpp test is filtered to only contain the relevant parts for conciseness.
- The script  `clean_trudag_output.py` is adjusted to remove unnecessary tabs from the trudag output to facilitate proper syntax highlighting in markdown