### PR TITLE
Add parent workflow

### DIFF
--- a/.github/workflows/check_amalgamation.yml
+++ b/.github/workflows/check_amalgamation.yml
@@ -1,7 +1,12 @@
 name: "Check amalgamation"
 
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -74,3 +79,15 @@ jobs:
           ${{ github.workspace }}/venv/bin/astyle --project=tools/astyle/.astylerc --suffix=orig $(find docs/examples include tests -type f \( -name '*.hpp' -o -name '*.cpp' -o -name '*.cu' \) -not -path 'tests/thirdparty/*' -not -path 'tests/abi/include/nlohmann/*' | sort)
           echo Check
           find $MAIN_DIR -name '*.orig' -exec false {} \+
+
+      - name: Generate amalgamation artifact
+        run: |
+          echo "Generating amalgamation artifact..."
+          mkdir -p check_amalgamation
+          echo "Amalgamation processed for ${{ inputs.artifact_id }}" > check_amalgamation/check_amalgamation.txt
+
+      - name: Upload amalgamation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_id }}
+          path: check_amalgamation/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,12 @@ on:
       - develop
       - main
       - release/*
-  pull_request:
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
   schedule:
     - cron: '0 19 * * 1'
   workflow_dispatch:
@@ -17,6 +22,7 @@ concurrency:
 
 permissions:
   contents: read
+  
 
 jobs:
   CodeQL-Build:
@@ -47,3 +53,15 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@fc7e4a0fa01c3cca5fd6a1fddec5c0740c977aa2 # v3.28.14
+
+    - name: Generate codeql artifact
+      run: |
+        echo "Generating codeql artifact..."
+        mkdir -p codeql
+        echo "codeql processed for ${{ inputs.artifact_id }}" > codeql/codeql.txt
+
+    - name: Upload codeql artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_id }}
+        path: codeql/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,14 @@
 #
 # Source repository: https://github.com/actions/dependency-review-action
 name: 'Dependency Review'
-on: [pull_request]
+on:  
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
+
 
 permissions:
   contents: read
@@ -25,3 +32,16 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
+
+
+      - name: Generate dependency_review artifact
+        run: |
+          echo "Generating Dependency Review artifact..."
+          mkdir -p dependency_review
+          echo "dependency review processed for ${{ inputs.artifact_id }}" > dependency_review/dependency_review.txt
+
+      - name: Upload dependency_review artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_id }}
+          path: dependency_review/

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,12 @@
 name: "Pull Request Labeler"
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -24,3 +28,15 @@ jobs:
       - uses: srvaroa/labeler@e216fb40e2e6d3b17d90fb1d950f98bee92f65ce # master
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Generate label artifact
+        run: |
+          echo "Generating label artifact..."
+          mkdir -p labeler
+          echo "Labels processed for ${{ inputs.artifact_id }}" > labeler/labeler.txt
+
+      - name: Upload label artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_id }}
+          path: labeler/

--- a/.github/workflows/parent-workflow.yml
+++ b/.github/workflows/parent-workflow.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - develop
       - main
-      - copy_of_main
 
 permissions:
   contents: write
@@ -34,18 +33,18 @@ jobs:
     with:
       artifact_id: "test_trudag_extensions-${{ github.sha }}"
 
-  #codeql:
-  #  name: Run Codeql analysis Workflow
-  #  uses: ./.github/workflows/codeql-analysis.yml
-  #  with:
-  #    artifact_id: "codeql-${{ github.sha }}"
+  codeql:
+    name: Run Codeql analysis Workflow
+    uses: ./.github/workflows/codeql-analysis.yml
+    with:
+      artifact_id: "codeql-${{ github.sha }}"
 
-  #ubuntu:
-  #  name: Run Ubuntu Workflow
-  #  needs: [codeql] # Error if CodeQL and Ubuntu triggered at the same time due to conflicting priorities
-  #  uses: ./.github/workflows/ubuntu.yml
-  #  with:
-  #    artifact_id: "ubuntu-${{ github.sha }}"
+  ubuntu:
+    name: Run Ubuntu Workflow
+    needs: [codeql] # Error if CodeQL and Ubuntu triggered at the same time due to conflicting priorities
+    uses: ./.github/workflows/ubuntu.yml
+    with:
+      artifact_id: "ubuntu-${{ github.sha }}"
 
   dependency_review:
     name: Run dependency_review Workflow
@@ -57,11 +56,11 @@ jobs:
   collect-and-deploy-pr:
     name: "Collect Results & Deploy (PR)"
     if: github.event_name == 'pull_request'
-    needs: [labeler, check_amalgamation, test_trudag_extensions, dependency_review]
+    needs: [labeler, check_amalgamation, test_trudag_extensions, dependency_review, codeql, ubuntu]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [labeler, check_amalgamation, test_trudag_extensions, dependency_review]
+        target: [labeler, check_amalgamation, test_trudag_extensions, dependency_review, codeql, ubuntu]
 
     steps:
       - name: Checkout code
@@ -97,11 +96,11 @@ jobs:
   collect-and-deploy-non-pr:
     name: "Collect Results & Deploy (Non-PR)"
     if: github.event_name != 'pull_request'
-    needs: [labeler, check_amalgamation, test_trudag_extensions]  # no dependency_review if non PR
+    needs: [labeler, check_amalgamation, test_trudag_extensions, codeql, ubuntu]  # no dependency_review if non PR
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [labeler, check_amalgamation, test_trudag_extensions]
+        target: [labeler, check_amalgamation, test_trudag_extensions, codeql, ubuntu]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/parent-workflow.yml
+++ b/.github/workflows/parent-workflow.yml
@@ -1,5 +1,5 @@
 name: Parent Workflow
-#test
+
 on: 
   pull_request:
   push: 

--- a/.github/workflows/parent-workflow.yml
+++ b/.github/workflows/parent-workflow.yml
@@ -1,0 +1,134 @@
+name: Parent Workflow
+#test
+on: 
+  pull_request:
+  push: 
+    branches:
+      - develop
+      - main
+      - copy_of_main
+
+permissions:
+  contents: write
+  pages: write
+  pull-requests: write
+  id-token: write
+  security-events: write
+
+jobs:
+  labeler:
+    name: Run Labeler Workflow
+    uses: ./.github/workflows/labeler.yml
+    with:
+      artifact_id: "labeler-${{ github.sha }}"
+
+  check_amalgamation:
+    name: Run Amalgamation Workflow
+    uses: ./.github/workflows/check_amalgamation.yml
+    with:
+      artifact_id: "check_amalgamation-${{ github.sha }}"
+      
+  test_trudag_extensions:
+    name: Run Test Trudag Extensions Workflow
+    uses: ./.github/workflows/test_trudag_extensions.yml
+    with:
+      artifact_id: "test_trudag_extensions-${{ github.sha }}"
+
+  #codeql:
+  #  name: Run Codeql analysis Workflow
+  #  uses: ./.github/workflows/codeql-analysis.yml
+  #  with:
+  #    artifact_id: "codeql-${{ github.sha }}"
+
+  #ubuntu:
+  #  name: Run Ubuntu Workflow
+  #  needs: [codeql] # Error if CodeQL and Ubuntu triggered at the same time due to conflicting priorities
+  #  uses: ./.github/workflows/ubuntu.yml
+  #  with:
+  #    artifact_id: "ubuntu-${{ github.sha }}"
+
+  dependency_review:
+    name: Run dependency_review Workflow
+    if: ${{ github.event_name == 'pull_request' }} 
+    uses: ./.github/workflows/dependency-review.yml
+    with:
+      artifact_id: "dependency_review-${{ github.sha }}"
+
+  collect-and-deploy-pr:
+    name: "Collect Results & Deploy (PR)"
+    if: github.event_name == 'pull_request'
+    needs: [labeler, check_amalgamation, test_trudag_extensions, dependency_review]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [labeler, check_amalgamation, test_trudag_extensions, dependency_review]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check child workflow results 
+        run: |
+          echo "=== Checking Child Workflow Results ==="
+          result="${{ needs[matrix.target].result }}"
+          echo "${{ matrix.target }} workflow result: $result"
+
+          if [[ "$result" != "success" ]]; then
+            echo "❌ ${{ matrix.target }} workflow failed! Exiting..."
+            exit 1
+          fi
+          echo "✅ Child workflows completed successfully!" 
+        env:
+          current_workflow: ${{ matrix.target }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ matrix.target }}-${{ github.sha }}"
+          path: artifacts/
+
+      - name: Deployment simulation
+        run: |
+          echo "🚀 Simulating deployment..."
+          sleep 2
+          echo "✅ Deployment completed successfully!"
+
+
+  collect-and-deploy-non-pr:
+    name: "Collect Results & Deploy (Non-PR)"
+    if: github.event_name != 'pull_request'
+    needs: [labeler, check_amalgamation, test_trudag_extensions]  # no dependency_review if non PR
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [labeler, check_amalgamation, test_trudag_extensions]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check child workflow results 
+        run: |
+          echo "=== Checking Child Workflow Results ==="
+          result="${{ needs[matrix.target].result }}"
+          echo "${{ matrix.target }} workflow result: $result"
+
+          if [[ "$result" != "success" ]]; then
+            echo "❌ ${{ matrix.target }} workflow failed! Exiting..."
+            exit 1
+          fi
+          echo "✅ Child workflows completed successfully!" 
+        env:
+          current_workflow: ${{ matrix.target }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: "${{ matrix.target }}-${{ github.sha }}"
+          path: artifacts/
+
+      - name: Deployment simulation
+        run: |
+          echo "🚀 Simulating deployment..."
+          sleep 2
+          echo "✅ Deployment completed successfully!"

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch || 'main' }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || 'main' }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -20,13 +20,11 @@ permissions:
   id-token: write
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize] # Allows forks to trigger the docs build
-  push:
-    branches:
-      - main
-  merge_group:
-    types: [checks_requested]
+  workflow_run:
+    workflows: 
+     - "Parent Workflow"
+    types:
+      - completed
 
 jobs:
   run-trudag:
@@ -40,7 +38,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -51,6 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz
           pip install trustable --index-url https://gitlab.com/api/v4/projects/66600816/packages/pypi/simple
+      
 
       - name: Generate trudag report
         run: |

--- a/.github/workflows/test_trudag_extensions.yml
+++ b/.github/workflows/test_trudag_extensions.yml
@@ -1,9 +1,15 @@
 name: Test Trudag extensions
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -27,3 +33,15 @@ jobs:
       run: |
         cd .dotstop_extensions
         pytest -v
+
+    - name: Generate test_trudag_extensions artifact
+      run: |
+        echo "Generating test_trudag_extensions artifact..."
+        mkdir -p test_trudag_extensions
+        echo "test_trudag_extensions processed for ${{ inputs.artifact_id }}" > test_trudag_extensions/test_trudag_extensions.txt
+
+    - name: Upload test_trudag_extensions artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact_id }}
+        path: test_trudag_extensions/

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,13 +1,18 @@
 name: Ubuntu
 
 on:
+  workflow_call:
+    inputs:
+      artifact_id:
+        description: 'Unique identifier for artifacts'
+        required: true
+        type: string
+  workflow_dispatch:
   push:
     branches:
       - develop
       - main
       - release/*
-  pull_request:
-  workflow_dispatch:
   schedule:
   # Runs every day at 9:00 AM UTC
   - cron: "0 9 * * *"
@@ -253,3 +258,19 @@ jobs:
         run: cmake -S . -B build -DJSON_CI=On
       - name: Build
         run: cmake --build build --target ${{ matrix.target }}
+
+  ubuntu_artifact:
+    runs-on: ubuntu-latest
+    needs: [ci_test_gcc, ci_infer, ci_static_analysis_ubuntu, ci_static_analysis_clang, ci_cmake_options, ci_test_coverage, ci_test_compilers_gcc_old, ci_test_compilers_gcc, ci_test_compilers_clang, ci_test_standards_gcc, ci_test_standards_clang, ci_cuda_example, ci_icpc, ci_test_documentation]
+    steps:
+      - name: Generate ubuntu artifact
+        run: |
+          echo "Generating ubuntu artifact..."
+          mkdir -p ubuntu
+          echo "ubuntu processed for ${{ inputs.artifact_id }}" > ubuntu/ubuntu.txt
+
+      - name: Upload ubuntu artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_id }}
+          path: ubuntu/


### PR DESCRIPTION
**Full version of parent_workflow. 

Notes:**
- Only merge this full version after having successfully tested the add_parent_workflow_mini branch

- Parent workflow orchestrates the order of child workflows and gathers artifacts from them. Expectation is to have trudag job (in publish_documentation.yml) only run after the parent workflow has completed.

- Ubuntu workflow runs after codeql-analysis has completed. This is to avoid the two being triggered simultaneously which causes conflicting CI priorities, resulting in one being cancelled. Check if concurrency is causing this.

- Dependency review workflow results in error if triggered by non-PR. Current implementation includes two separate jobs for artifact processing, one for PR and one for non-PR.  Check if there is cleaner solution.
