### PR TITLE
Use test data mirror

### DIFF
--- a/.dotstop_extensions/references.py
+++ b/.dotstop_extensions/references.py
@@ -4,7 +4,7 @@ import requests
 
 # Constants
 MAX_JSON_LINES_FOR_DISPLAY = 25
-TEST_DATA_REPO_URL = "https://raw.githubusercontent.com/score-json/json/refs/heads/json_test_data_version_3_1_0_mirror/"
+TEST_DATA_REPO_URL = "https://raw.githubusercontent.com/eclipse-score/inc_nlohmann_json/refs/heads/json_test_data_version_3_1_0_mirror/"
 NUM_WHITESPACE_FOR_TAB = 4
 
 def format_cpp_code_as_markdown(code: str) -> str:

--- a/cmake/ci.cmake
+++ b/cmake/ci.cmake
@@ -454,7 +454,7 @@ add_custom_target(ci_infer
 
 add_custom_target(ci_offline_testdata
     COMMAND mkdir -p ${PROJECT_BINARY_DIR}/build_offline_testdata/test_data
-    COMMAND cd ${PROJECT_BINARY_DIR}/build_offline_testdata/test_data && ${GIT_TOOL} clone --branch json_test_data_version_3_1_0_mirror https://github.com/score-json/json.git --quiet --depth 1 json_test_data
+    COMMAND cd ${PROJECT_BINARY_DIR}/build_offline_testdata/test_data && ${GIT_TOOL} clone --branch json_test_data_version_3_1_0_mirror https://github.com/eclipse-score/inc_nlohmann_json.git --quiet --depth 1 json_test_data
     COMMAND ${CMAKE_COMMAND}
         -DCMAKE_BUILD_TYPE=Debug -GNinja
         -DJSON_BuildTests=ON -DJSON_FastTests=ON -DJSON_TestDataDirectory=${PROJECT_BINARY_DIR}/build_offline_testdata/test_data/json_test_data

--- a/cmake/download_test_data.cmake
+++ b/cmake/download_test_data.cmake
@@ -1,4 +1,4 @@
-set(JSON_TEST_DATA_URL     https://github.com/score-json/json)
+set(JSON_TEST_DATA_URL     https://github.com/eclipse-score/inc_nlohmann_json)
 set(JSON_TEST_DATA_BRANCH json_test_data_version_3_1_0_mirror)
 
 # if variable is set, use test data from given directory rather than downloading them


### PR DESCRIPTION
The nlohmann_json library uses test data from an [external repository](https://github.com/nlohmann/json_test_data). We mirror this data in a branch inside the this repo right now. 

We try to setup a test_data_mirror branch in the the eclipse-score/inc_nlohmann_json repository. Once this is completed, we should adjust the links and merge this. 