### PR TITLE
auto compare and clone labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,8 +10,51 @@ on:
 
 permissions:
   contents: read
-
+  
 jobs:
+  clone_missing_labels:
+    permissions: 
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+    steps:
+    - name: compare labels
+      run: |
+        # Source repository (the one we're cloning labels FROM)
+        SOURCE_REPO="nlohmann/json"
+
+        # Dynamically determine the current repository (target repository)
+        TARGET_REPO="${GITHUB_REPOSITORY}"
+
+        echo "Cloning labels from $SOURCE_REPO to $TARGET_REPO..."
+
+        # Fetch labels from the source repository
+        SOURCE_LABELS=$(gh label list --repo "$SOURCE_REPO" --json name,color,description --limit 1000)
+
+        # Fetch labels from the target repository for comparison
+        TARGET_LABELS=$(gh label list --repo "$TARGET_REPO" --json name --limit 1000)
+
+        # Loop through all labels in the source repository
+        echo "$SOURCE_LABELS" | jq -c '.[]' | while read -r label; do
+          LABEL_NAME=$(echo "$label" | jq -r '.name')
+          LABEL_COLOR=$(echo "$label" | jq -r '.color')
+          LABEL_DESCRIPTION=$(echo "$label" | jq -r '.description')
+
+          # Check if the label already exists in the target repository
+          if ! echo "$TARGET_LABELS" | jq -e --arg NAME "$LABEL_NAME" '.[] | select(.name == $NAME)' > /dev/null; then
+            # Create the label if it doesn't exist
+            echo "Creating label: $LABEL_NAME..."
+            gh label create "$LABEL_NAME" --repo "$TARGET_REPO" --color "$LABEL_COLOR" --description "$LABEL_DESCRIPTION"
+          else
+            echo "Label '$LABEL_NAME' already exists in $TARGET_REPO. Skipping..."
+          fi
+        done
+
+        echo "All labels cloned successfully!"
+
   label:
     permissions:
       contents: read


### PR DESCRIPTION
Repo does not by default clone labels from upstream (nlohmann/json). As such, some labels assigned by the labels.yml workflow were never processed. Ultimately, this affected the contents of the resulting artifact and validator score.

- Use gh label tool for managing labels (see [https://github.com/cli/cli/issues/446](https://github.com/cli/cli/issues/446).
- With each run of label.yml workflow, automatically compare the labels of nlohmann/json with current repo.
- If label exists in nlohmann/json but not in current repo, create it in the current repo with identical label color and label description.
- Any label name that already exists in current repo is skipped (even if it has different color or description than in nlohmann/json).