### PR TITLE
Add real artifacts

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -33,12 +33,19 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@ce3cf9537a52e8119d91fd484ab5b8a807627bf8 # v4.6.0
 
-
-      - name: Generate dependency_review artifact
+      - name: Generate Dependency Review Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Generating Dependency Review artifact..."
+          echo "Creating Dependency Review artifact..."
+
+          # Create the directory for the artifact
           mkdir -p dependency_review
-          echo "dependency review processed for ${{ inputs.artifact_id }}" > dependency_review/dependency_review.txt
+
+          echo "${{ steps.dependency-review.outputs.comment-content }}" > dependency_review/summary.html
+
+          # Single quotation marks are used to prevent JSON parsing issues
+          echo '${{ steps.dependency-review.outputs.dependency-changes }}' | jq '.' > dependency_review/dependency_changes.json
 
       - name: Upload dependency_review artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -76,10 +76,29 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Generate label artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Generating label artifact..."
           mkdir -p labeler
-          echo "Labels processed for ${{ inputs.artifact_id }}" > labeler/labeler.txt
+
+          echo "Workflow Name: Pull Request Labeler" > labeler/labeler.txt
+          echo "Artifact ID: ${{ inputs.artifact_id }}" >> labeler/labeler.txt
+
+          # Get PR number from GitHub context
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+
+          # Fetch labels from the PR using GitHub API
+          LABELS=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/labels" | jq -r '.[].name' | xargs)
+
+          if [[ -n "$LABELS" ]]; then
+            echo "Labels Applied:" >> labeler/labeler.txt
+            echo "$LABELS" >> labeler/labeler.txt
+          else
+            echo "No labels were applied." >> labeler/labeler.txt
+          fi
 
       - name: Upload label artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Workflow artifacts were initially set up with placeholder logic for testing purposes and for connecting validators. 

- Add real artifacts with data/results/information on the workflow outcome, which are to be used for validator scoring.