### PR TITLE
Configure Coveralls publishing

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -124,6 +124,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ${{ github.workspace }}/build/json.info.filtered.noexcept
+          fail-on-error: false # Do not fail the workflow if Coveralls fails
 
   ci_test_compilers_gcc_old:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Coveralls occasionally experience server issues, resulting in coverage publishing to fail. As a result the workflow fails and trudag is not triggered.

- Configure "Publish report to Coveralls" to continue on error.
- If publishing fails, LCOV coverage report is still created and archived as artifact