### PR TITLE
Fix dangerous workflow -use env instead of shell

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -50,9 +50,10 @@ jobs:
       
       - name: Get current branch name
         id: get_branch
+        env:
+          GITHUB_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          current_branch=${{ github.event.pull_request.head.ref }}
-          echo "branch_name=$current_branch" >> $GITHUB_ENV
+          echo "branch_name=${GITHUB_REF}" >> $GITHUB_ENV
 
       - name: Fetch data storage branch
         run: |

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -64,7 +64,7 @@ jobs:
             git commit -m "Initialise persistent data storage"
             git push origin save_historical_data
           fi
-          git checkout main
+          git checkout ${{ github.event.repository.default_branch }}
           git checkout save_historical_data -- TSF/TrustableScoring.db
 
       - name: Generate trudag report
@@ -90,7 +90,7 @@ jobs:
       
       - name: Recover stash
         run: |
-          git checkout main
+          git checkout ${{ github.event.repository.default_branch }}
           git stash apply
 
       - name: Upload trudag artifact

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -47,13 +47,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y graphviz
           pip install git+https://gitlab.com/CodethinkLabs/trustable/trustable@cc6b72753e1202951d382f60ff08320f5a957c7b
-      
-      - name: Get current branch name
-        id: get_branch
-        env:
-          GITHUB_REF: ${{ github.event.pull_request.head.ref }}
-        run: |
-          echo "branch_name=${GITHUB_REF}" >> $GITHUB_ENV
 
       - name: Fetch data storage branch
         run: |
@@ -71,7 +64,7 @@ jobs:
             git commit -m "Initialise persistent data storage"
             git push origin save_historical_data
           fi
-          git checkout $branch_name
+          git checkout main
           git checkout save_historical_data -- TSF/TrustableScoring.db
 
       - name: Generate trudag report
@@ -97,13 +90,13 @@ jobs:
       
       - name: Recover stash
         run: |
-          git checkout $branch_name
+          git checkout main
           git stash apply
 
       - name: Upload trudag artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: trudag-report-${{ github.event.pull_request.head.sha || github.sha }}
+          name: trudag-report-${{ github.sha }}
           path: TSF/docs/generated/
           if-no-files-found: error
           


### PR DESCRIPTION
Directly invoking a shell script with github.event.pull_request.head.ref as input results  in script injection risks (see [security alert 63](https://github.com/score-json/json/security/code-scanning/63) ). 