### PR TITLE
add time of execution to TestResultData.db

### DIFF
--- a/.dotstop_extensions/data_store.py
+++ b/.dotstop_extensions/data_store.py
@@ -71,12 +71,10 @@ def push_my_data(data: list[dict]):
     # extract data from data
     info = data[0].get("info")
     scores = data[0].get("scores")
-    print(info)
     # Currently, the commit date is stored as string.
     # Since the local timezone is used and for comparison, 
     # it would be better to have it as a unix-timestamp.
     datum_string = info.get("Commit date/time")
-    print(f"The current commit is from {datum_string}.")
     datum = int(datetime.strptime(datum_string, "%a %b %d %H:%M:%S %Y").timestamp())
     # check if current commit coincides with existing commit
     cursor.execute("SELECT MAX(date) AS recent_commit FROM commit_info")
@@ -96,6 +94,10 @@ def push_my_data(data: list[dict]):
     for score in scores:
         id = score.get("id")
         numerical_score = score.get("score")
+        cursor.execute("SELECT COUNT(*) FROM scores WHERE date = ? AND ID = ?", (datum, id))
+        if cursor.fetchone()[0]>0:
+            cursor.execute("DELETE FROM scores WHERE date = ? AND ID = ?", (datum, id))
+            connector.commit()
         command = f"INSERT OR REPLACE INTO scores VALUES('{id}', {numerical_score}, '{datum}')"
         cursor.execute(command)
     # don't forget to commit!

--- a/.github/workflows/parent-workflow.yml
+++ b/.github/workflows/parent-workflow.yml
@@ -122,16 +122,8 @@ jobs:
 
   publish_documentation_pr:
     name: Run publish_documentation Workflow pr
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push' && github.ref_name == 'main'
     needs: [collect_artifacts_pr]
-    uses: ./.github/workflows/publish_documentation.yml
-    with:
-      artifact_id: "publish_documentation-${{ github.sha }}"
-
-  publish_documentation_non_pr:
-    name: Run publish_documentation Workflow non pr
-    if: github.event_name != 'pull_request'
-    needs: [collect_artifacts_non_pr]
     uses: ./.github/workflows/publish_documentation.yml
     with:
       artifact_id: "publish_documentation-${{ github.sha }}"

--- a/TSF/scripts/add_time.py
+++ b/TSF/scripts/add_time.py
@@ -1,0 +1,56 @@
+import sys
+import sqlite3
+from datetime import datetime
+from urllib import request, error
+import json
+
+# This is a script, which adds the missing column time to the TestResultData.db
+# The reason for this change is a changed rationale with the temporary proof-of-concept implementation of the test-data storage
+
+
+def from_rest_api(repo, run_id):
+    """Query the Actions run object and return run_started_at."""
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}"
+    req = request.Request(url)
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("User-Agent", "gha-run-start-python-script/1.0")
+    req.add_header("Authorization", "Bearer {ADD_YOUR_OWN_TOKEN_HERE}")
+
+    try:
+        with request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+        return data.get("run_started_at")
+    except error.HTTPError as e:
+        msg = e.read().decode("utf-8", errors="ignore")
+        print(f"HTTP {e.code} when calling GitHub API: {msg}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error calling GitHub API: {e}", file=sys.stderr)
+        return None
+
+def column_exists(conn, table, column):
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cur.fetchall())  # row[1] = name
+
+# initiate connection to database
+connector = sqlite3.connect("TSF/TestResultData.db")
+connector.execute("PRAGMA foreign_keys = ON")
+
+if not column_exists(connector, "workflow_info", "time"):
+    connector.execute("ALTER TABLE workflow_info ADD COLUMN time INT DEFAULT -1")
+
+cursor = connector.cursor()
+
+
+cursor.execute("SELECT * FROM workflow_info")
+rows = cursor.fetchall()
+for row in rows:
+    # t = int(datetime.fromisoformat(from_rest_api(row[0],row[1])).timestamp())
+    # command = f"UPDATE workflow_info SET time = {t} WHERE repo = \"{row[0]}\" AND run_id = {str(row[1])} AND run_attempt = {str(row[2])}"
+    # cursor.execute(command)
+    # connector.commit()
+    print(row)
+
+connector.commit()
+connector.close()


### PR DESCRIPTION
* previously, time of execution not explicitly stored
* since storage is limited, we limit storage of test-results temporarily
* to save ressources when searching for the oldest results, we save time of execution in the database, and do not query github api

* Due to the changed rationale, add the times manually using python script add_time.py.