### PR TITLE
Review round 2 jk

### DIFF
--- a/.dotstop_extensions/references.py
+++ b/.dotstop_extensions/references.py
@@ -516,13 +516,13 @@ class FunctionReference(SourceSpanReference):
                     return [start_line,line_number]
         if not in_class:
             raise ValueError(f"Could not find class {name_parts[0]} in file {path}")
-        if not in_body and overload%10 == 1 and overload%100 != 11:
+        if not found_start and overload%10 == 1 and overload%100 != 11:
             raise ValueError(f"Could not locate {overload}st implementation of {name_parts[1]} in file {path}.")
-        elif not in_body and overload%10 == 2 and overload%100 != 12:
+        elif not found_start and overload%10 == 2 and overload%100 != 12:
             raise ValueError(f"Could not locate {overload}nd implementation of {name} in file {path}.")
-        elif not in_body and overload%10 == 3 and overload%100 != 13:
+        elif not found_start and overload%10 == 3 and overload%100 != 13:
             raise ValueError(f"Could not locate {overload}rd implementation of {name} in file {path}.")
-        elif not in_body:
+        elif not found_start:
             raise ValueError(f"Could not locate {overload}th implementation of {name} in file {path}.")
         else:
             raise ValueError(f"Could not find end of function-body of {name} in file {path}.")

--- a/.dotstop_extensions/references.py
+++ b/.dotstop_extensions/references.py
@@ -465,12 +465,12 @@ class FunctionReference(SourceSpanReference):
         instance = 0
         start_line = 0
         found_start = False
+        in_body = False
         for line_number, line in enumerate(lines):
             # first task: find literal string "class class_name " within a line
             if not in_class:
                 if f"class {name_parts[0]} " in line or f"class {name_parts[0]}\n" in line:
                     in_class = True
-                    continue
                 continue
             # now we are within the class
             # time to search for our function
@@ -510,19 +510,19 @@ class FunctionReference(SourceSpanReference):
                                 sections.pop()
                             except IndexError:
                                 raise ValueError(f"Fatal error: Could not resolve {name} in file {path}.")
-                if not found_start and len(sections)>0:
-                    found_start = True
-                if found_start and len(sections)==0:
+                if not in_body and len(sections)>0:
+                    in_body = True
+                if in_body and len(sections)==0:
                     return [start_line,line_number]
         if not in_class:
             raise ValueError(f"Could not find class {name_parts[0]} in file {path}")
-        if overload%10 == 1 and overload != 11:
+        if not in_body and overload%10 == 1 and overload%100 != 11:
             raise ValueError(f"Could not locate {overload}st implementation of {name_parts[1]} in file {path}.")
-        elif overload%10 == 2 and overload != 12:
+        elif not in_body and overload%10 == 2 and overload%100 != 12:
             raise ValueError(f"Could not locate {overload}nd implementation of {name} in file {path}.")
-        elif overload%10 == 3 and overload != 13:
+        elif not in_body and overload%10 == 3 and overload%100 != 13:
             raise ValueError(f"Could not locate {overload}rd implementation of {name} in file {path}.")
-        elif not found_start:
+        elif not in_body:
             raise ValueError(f"Could not locate {overload}th implementation of {name} in file {path}.")
         else:
             raise ValueError(f"Could not find end of function-body of {name} in file {path}.")

--- a/.dotstop_extensions/test_references.py
+++ b/.dotstop_extensions/test_references.py
@@ -590,6 +590,33 @@ def test_get_function_boundaries():
     ]
     assert FunctionReference.get_function_boundaries("foo","lexer::my_function",lines,1) == [16,19]
     
+def test_get_function_boundaries_with_multiline_declaration():
+    lines = [
+        'template<typename BasicJsonType>\n',
+        'class lexer_base\n',
+        '{\n',
+        '    // class body\n',
+        '};\n',
+        '\n',
+        'template<typename BasicJsonType, typename InputAdapterType>\n',
+        'class lexer : public lexer_base<BasicJsonType>\n',
+        '{\n',
+        '\n',
+        '  private\n',
+        '    bool dummy_function()\n',
+        '    {\n',
+        '        return my_function();\n',
+        '    }\n',
+        '\n',
+        '    bool my_function(int: foo,',
+        '                       bool: bar)\n',
+        '    {\n',
+        '        // function body \n',
+        '    }\n',
+        '};\n'
+    ]
+    assert FunctionReference.get_function_boundaries("foo","lexer::my_function",lines,1) == [16,20]
+    
 def test_get_function_boundaries_with_multiple_overloads():
     lines = [
         'template<typename BasicJsonType>\n',


### PR DESCRIPTION
fix bug in FunctionReference.get_function_boundaries

* previously, function declarations whose body did not start immediately below the first line of the function name were handled wrongly
* also fix error message for (unlikely) case of more than 100 overloads
