### PR TITLE
Rework data storage

### DIFF
--- a/TSF/scripts/README.md
+++ b/TSF/scripts/README.md
@@ -20,7 +20,7 @@ Moreover, a size-check is performed on the persistent storage, using the followi
 
 * It is expected, that an update of a test-result only happens, when a test fails, which leads automatically to the failure of the pipeline, which should trigger a manual review by the maintainer, or failed before.
 * It is expected, that tests fail rarely, and in particular on average less than 10 different test-cases per workflow-run fail.
-* It is expected, that less than 1,000 worflow runs, where a record of the test-result is triggered, happen per year, since these are only triggered once daily and on each push to main.
+* It is expected, that less than 1,000 workflow runs, where a record of the test-result is triggered, happen per year, since these are only triggered once daily and on each push to main.
 * It is expected, that a ten-year-record of test-results is sufficient for documentation purposes.
 
 In view of these assumptions, we limit the storage to approximately 100,000 test-results and 100,000 workflow-metadata, which guarantees *en passant* that github's file size limit of 100MB is respected.

--- a/TSF/scripts/README.md
+++ b/TSF/scripts/README.md
@@ -16,6 +16,17 @@ The characterisation of "relevant change" follows the following heuristic argume
 * The execution time of each test is of lesser interest, therefore it is not continuously updated.
 * A test is uniquely identified by the columns ctest_target, name and cpp_standard.
 
+Moreover, a size-check is performed on the persistent storage, using the following heuristic assumptions 
+
+* It is expected, that an update of a test-result only happens, when a test fails, which leads automatically to the failure of the pipeline, which should trigger a manual review by the maintainer, or failed before.
+* It is expected, that tests fail rarely, and in particular on average less than 10 different test-cases per workflow-run fail.
+* It is expected, that less than 1,000 worflow runs, where a record of the test-result is triggered, happen per year, since these are only triggered once daily and on each push to main.
+* It is expected, that a ten-year-record of test-results is sufficient for documentation purposes.
+
+In view of these assumptions, we limit the storage to approximately 100,000 test-results and 100,000 workflow-metadata, which guarantees *en passant* that github's file size limit of 100MB is respected.
+In the worst case that every recorded test result is detected as a relevant change, this restraint collects test-results from 27 workflows in total.
+Whenever either limit of 100,000 test-results and 100,000 workflow-metadata in the persistent data storage is violated, the script returns the error "The persistent data storage is too large! Please move persistent data to external storage.", thereby failing the workflow, which advises the maintainer to take up action.
+
 ## clean_trudag_report.py
 
 The python-script [clean_trudag_report.py](clean_trudag_report.py) runs at the end of generate_report.sh.

--- a/TSF/scripts/capture_test_data.py
+++ b/TSF/scripts/capture_test_data.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     cursor.execute(''.join(command))
     command = (
         "CREATE TABLE IF NOT EXISTS test_results(",
-        "timestamp INT, "                           # when the test-run was started
+        "timestamp INT, "   # NEEDS TO BE REMOVED!!!                        # when the test-run was started
         "name TEXT, ",                              # name of the test
         "execution_time REAL, ",                    # execution time in seconds
         "compiler TEXT, ",                          # compiler information

--- a/TSF/scripts/capture_test_data.py
+++ b/TSF/scripts/capture_test_data.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
     cursor.execute(''.join(command))
     command = (
         "CREATE TABLE IF NOT EXISTS test_results(",
-        "timestamp INT, "   # NEEDS TO BE REMOVED!!!                        # when the test-run was started
+        "timestamp INT, "                           # when the test-run was started
         "name TEXT, ",                              # name of the test
         "execution_time REAL, ",                    # execution time in seconds
         "compiler TEXT, ",                          # compiler information

--- a/TSF/scripts/capture_test_data.py
+++ b/TSF/scripts/capture_test_data.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         "run_attempt INT, ",                        # Attempt-number of workflow run
         "status TEXT ",                             # Termination-status of workflow                                         
         "CHECK(status IN ('successful', 'failed', 'cancelled')) DEFAULT 'failed', ",
-    "time INT, ",                               # the time that is associated to this workflow run
+        "time INT, ",                               # the time that is associated to this workflow run
         "PRIMARY KEY(repo, run_id, run_attempt))"
     )
     cursor.execute(''.join(command))

--- a/TSF/scripts/capture_test_data_memory_sensitive.py
+++ b/TSF/scripts/capture_test_data_memory_sensitive.py
@@ -176,7 +176,6 @@ if __name__ == "__main__":
         "repo TEXT, ",                              # repository
         "run_id INT, ",                             # ID of workflow run
         "run_attempt INT, ",                        # Attempt-number of workflow run
-        "PRIMARY KEY(ctest_target, name, cpp_standard, compiler), "
         "FOREIGN KEY(repo, run_id, run_attempt) REFERENCES workflow_info);"
         )
     connector.execute(''.join(command))

--- a/TSF/scripts/capture_test_data_memory_sensitive.py
+++ b/TSF/scripts/capture_test_data_memory_sensitive.py
@@ -101,7 +101,7 @@ def find_most_recent_results(target: str, name: str, compiler: str, cpp_standard
                         workflow_info.repo = test_results.repo 
                         AND workflow_info.run_id = test_results.run_id 
                         AND workflow_info.run_attempt = test_results.run_attempt
-                        WHERE test_results.ctest_target = ? AND test_results.compiler = ? AND test_results.name = ? AND test_results.cpp_standard = ?
+                        WHERE test_results.ctest_target = ? AND test_results.name = ? AND test_results.compiler = ? AND test_results.cpp_standard = ?
                     )
                     SELECT repo, run_id, run_attempt FROM combination
                     ORDER BY time DESC, run_id DESC, run_attempt DESC

--- a/TSF/scripts/capture_test_data_memory_sensitive.py
+++ b/TSF/scripts/capture_test_data_memory_sensitive.py
@@ -181,6 +181,13 @@ if __name__ == "__main__":
     connector.execute(''.join(command))
     cursor = connector.cursor()
 
+    # Count number of rows as heuristic size-checker.
+    # In case that the update-check fails, and every result is stored, allow for approximately 26 complete results to be stored
+    cursor.execute("SELECT MAX(COALESCE((SELECT MAX(rowid) FROM workflow_info),0),COALESCE((SELECT MAX(rowid) FROM test_results),0));")
+    if cursor.fetchone()[0] > 1e5:
+        connector.close()
+        raise RuntimeError("The persistent data storage is too large! Please move persistent data to external storage.")
+
     # fill in metadata
     # OBSERVE: This script expects the status of the github workflow as argument
     repo = environment.get('GITHUB_REPOSITORY')


### PR DESCRIPTION
Two mistakes are fixed:
1. Primary key in table test_results is removed.
2. Wrong order of arguments when fetching the most recent test result is corrected.

Additionally, a heuristic size check is added and documented.