### PR TITLE
Erikhu1 add codeowners and release process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,8 @@
 # JSON for Modern C++ was originally written by Niels Lohmann.
-# Since 2013, over 250 contributors have helped to improve the library.
-# This CODEOWNERS file is only to make sure that @nlohmann is requested
-# for a code review in case of a pull request.
+
+# GitHub CODEOWNERS file is a simple way to automate review system on github,
+# by automatically assigning owners to a pull request based on which files
+# were modified. All directories should have a proper codeowner
+# Syntax: https://help.github.com/articles/about-codeowners/
+
+*                                     @4og @masc2023 @aschemmel-tech

--- a/TSF/README.md
+++ b/TSF/README.md
@@ -10,21 +10,10 @@ The TSF graph (including links, nodes and their hashes) is saved in the `.dotsto
 
 # Forking the repository
 
-In order to fork this repository or set up any repository where the TSF documentation in this repository is to be included, the following settings have to be configured on GitHub.
+In order to fork this repository or set up any repository where the TSF documentation in this repository is to be included, the following settings have to be configured on GitHub. In addition to the below settings, make sure to also configure appropriate branch protection rules. 
 
 - In `Settings` > `General` >`Features`:
     - Enable `Issues`
-    
-- In `Settings` > `Code and automation` > `Branches`:
-    - Click `Add classic branch protection rule` and add "main" to the `Branch name pattern` 
-    - Make sure that only the following settings are enabled:
-        - `Require a pull request before merging`
-        - `Require approvals`
-        - `Require review from Code Owners`
-        - `Require status checks to pass before merging`
-        - `Require branches to be up to date before merging`
-        - `Require linear history`
-        - `Do not allow bypassing the above settings`
 
 - In `Settings` > `Code and automation` > `Actions` > `General` > `Workflow Permissions`:
     - Make sure that only the following settings are enabled:

--- a/TSF/README.md
+++ b/TSF/README.md
@@ -32,3 +32,15 @@ In order to fork this repository or set up any repository where the TSF document
 - In `Actions tab`:
     - Click `I understand my workflows, go ahead and enable them`
     - In the left side menu, click `Show more workflows...` and enable any workflows which are labelled as `Disabled`
+
+# Release management 
+
+The releases process of this repository shall conform to the [release management plan of Eclipse S-CORE](https://github.com/eclipse-score/score/blob/668bae4d1a704565983d34b8447d5a035696299a/docs/platform_management_plan/release_management.rst#id11). Most notably, the release tags shall follow semantic versioning format.
+
+- The components of the tag shall be incremented both in case of an update to TSF documentation, and in case of updating to a new release of the upstream nlohmann/json library.
+- Updates to TSF documentation shall increment the PATCH or MINOR component.
+- Updating the version of nlohmann/json to a new release shall increment the appropriate tag component based on the extensiveness and nature of the upstream changes.
+- To indicate the version of nlohmann/json in use, the nlohmann/json release tag shall always be clearly included in the release notes of this repository.
+- The release notes of this repository shall always indicate whether the release includes changes to only TSF documentation, only the version of nlohmann/json, or both.
+
+To update either the version of nlohmann/json within S-CORE or TSF documentation, please refer to the respective Update Concepts below.


### PR DESCRIPTION
- Added CODEOWNERS (requested in https://github.com/eclipse-score/.eclipsefdn/pull/93)
- Added release management guide
- Removed branch protection setup from forking guide, as it is highly dependent on how the fork will be used.

Note that the CODEOWNERS file will be labelled as faulty in this repo, since Andrey Babanin and Markus Schu do not have write access in this repo. Once we migrate into eclipse-score however, they will be recognized, as they are all committers.
<img width="572" height="248" alt="image" src="https://github.com/user-attachments/assets/a3a8e590-17aa-4665-899f-07f85dc1843f" />
