### PR TITLE
remove codeowners for now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,3 @@
 # were modified. All directories should have a proper codeowner
 # Syntax: https://help.github.com/articles/about-codeowners/
 
-*                                     @4og @masc2023 @aschemmel-tech


### PR DESCRIPTION
Removing codeowners from this repo as it is auto-requesting reviews from the codeowners (which is annoying). Will re-add the codeowners after/during migration to eclipse-score/inc_nlohmann_json.